### PR TITLE
feat: print stack trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 **/Cargo.lock
 **/target/
 
-os/src/link_app.S
+# os/src/link_app.S
 os/src/linker.ld
 os/last-*
 os/Cargo.lock

--- a/os/src/link_app.S
+++ b/os/src/link_app.S
@@ -1,0 +1,63 @@
+
+    .align 3
+    .section .data
+    .global _num_app
+_num_app:
+    .quad 7
+    .quad app_0_start
+    .quad app_1_start
+    .quad app_2_start
+    .quad app_3_start
+    .quad app_4_start
+    .quad app_5_start
+    .quad app_6_start
+    .quad app_6_end
+
+    .section .data
+    .global app_0_start
+    .global app_0_end
+app_0_start:
+    .incbin "../user/target/riscv64gc-unknown-none-elf/release/00_hello_world.bin"
+app_0_end:
+
+    .section .data
+    .global app_1_start
+    .global app_1_end
+app_1_start:
+    .incbin "../user/target/riscv64gc-unknown-none-elf/release/01_store_fault.bin"
+app_1_end:
+
+    .section .data
+    .global app_2_start
+    .global app_2_end
+app_2_start:
+    .incbin "../user/target/riscv64gc-unknown-none-elf/release/02_power.bin"
+app_2_end:
+
+    .section .data
+    .global app_3_start
+    .global app_3_end
+app_3_start:
+    .incbin "../user/target/riscv64gc-unknown-none-elf/release/03_priv_inst.bin"
+app_3_end:
+
+    .section .data
+    .global app_4_start
+    .global app_4_end
+app_4_start:
+    .incbin "../user/target/riscv64gc-unknown-none-elf/release/04_priv_csr.bin"
+app_4_end:
+
+    .section .data
+    .global app_5_start
+    .global app_5_end
+app_5_start:
+    .incbin "../user/target/riscv64gc-unknown-none-elf/release/05_ultimate_answer.bin"
+app_5_end:
+
+    .section .data
+    .global app_6_start
+    .global app_6_end
+app_6_start:
+    .incbin "../user/target/riscv64gc-unknown-none-elf/release/06_print_stack_trace.bin"
+app_6_end:

--- a/user/src/bin/06_print_stack_trace.rs
+++ b/user/src/bin/06_print_stack_trace.rs
@@ -1,0 +1,45 @@
+#![no_std]
+#![no_main]
+
+#[macro_use]
+extern crate user_lib;
+
+use core::arch::asm;
+
+#[no_mangle]
+fn main() -> i32 {
+    foo();
+    0
+}
+
+fn foo() {
+    let _tmp = 0;
+    bar();
+}
+
+fn bar() {
+    let _tmp1 = 1;
+    let _tmp2 = 2;
+    print_sum(1, 2);
+}
+
+fn print_sum(left: i32, right: i32) {
+    let sum = left + right;
+    print(sum);
+}
+
+fn print(_value: i32) {
+    print_stack_trace();
+}
+
+fn print_stack_trace() {
+    let mut fp: usize = 0;
+    unsafe { asm!("mv {}, fp", out(reg) fp) };
+
+    while fp != 0 {
+        println!("fp = {:x}", fp);
+
+        let fp_ptr: *const u64 = { unsafe { (fp as *const u64).offset(-2) } };
+        fp = unsafe { (*fp_ptr).try_into().unwrap() };
+    }
+}

--- a/user/src/bin/06_print_stack_trace.rs
+++ b/user/src/bin/06_print_stack_trace.rs
@@ -13,22 +13,27 @@ fn main() -> i32 {
 }
 
 fn foo() {
-    let _tmp = 0;
+    let tmp = 0;
+    println!("tmp {:p}", &tmp);
     bar();
 }
 
 fn bar() {
-    let _tmp1 = 1;
-    let _tmp2 = 2;
+    let tmp1 = 1;
+    let tmp2 = 2;
+    println!("tmp1 {:p}", &tmp1);
+    println!("tmp2 {:p}", &tmp2);
     print_sum(1, 2);
 }
 
 fn print_sum(left: i32, right: i32) {
     let sum = left + right;
+    println!("sum {:p}", &sum);
     print(sum);
 }
 
-fn print(_value: i32) {
+fn print(value: i32) {
+    println!("value {:p}", &value);
     unsafe { print_stack_trace() };
 }
 
@@ -40,7 +45,7 @@ unsafe fn print_stack_trace() {
     while fp != core::ptr::null() {
         let saved_ra = *fp.sub(1);
         let saved_fp = *fp.sub(2);
-        println!("ra = 0x{:016x}, fp = 0x{:016x}", saved_ra, saved_fp);
+        println!("ra = 0x{:08x}, fp = 0x{:08x}", saved_ra, saved_fp);
 
         fp = saved_fp as *const usize
     }

--- a/user/src/bin/06_print_stack_trace.rs
+++ b/user/src/bin/06_print_stack_trace.rs
@@ -29,17 +29,20 @@ fn print_sum(left: i32, right: i32) {
 }
 
 fn print(_value: i32) {
-    print_stack_trace();
+    unsafe { print_stack_trace() };
 }
 
-fn print_stack_trace() {
-    let mut fp: usize = 0;
+unsafe fn print_stack_trace() {
+    let mut fp: *const usize;
     unsafe { asm!("mv {}, fp", out(reg) fp) };
 
-    while fp != 0 {
-        println!("fp = {:x}", fp);
+    println!("== Begin stack trace ==");
+    while fp != core::ptr::null() {
+        let saved_ra = *fp.sub(1);
+        let saved_fp = *fp.sub(2);
+        println!("ra = 0x{:016x}, fp = 0x{:016x}", saved_ra, saved_fp);
 
-        let fp_ptr: *const u64 = { unsafe { (fp as *const u64).offset(-2) } };
-        fp = unsafe { (*fp_ptr).try_into().unwrap() };
+        fp = saved_fp as *const usize
     }
+    println!("== End stack trace ==");
 }

--- a/user/src/bin/06_print_stack_trace.rs
+++ b/user/src/bin/06_print_stack_trace.rs
@@ -8,35 +8,70 @@ use core::arch::asm;
 
 #[no_mangle]
 fn main() -> i32 {
-    foo();
+    unsafe {
+        println!("");
+        println!("main");
+        print_stack_trace()
+    };
+
+    a();
     0
 }
 
-fn foo() {
-    let tmp = 0;
-    println!("tmp {:p}", &tmp);
-    bar();
+#[no_mangle]
+fn a() {
+    unsafe {
+        println!("");
+        println!("a");
+        print_stack_trace()
+    };
+
+    b();
 }
 
-fn bar() {
-    let tmp1 = 1;
-    let tmp2 = 2;
-    println!("tmp1 {:p}", &tmp1);
-    println!("tmp2 {:p}", &tmp2);
-    print_sum(1, 2);
+#[no_mangle]
+fn b() {
+    unsafe {
+        println!("");
+        println!("b");
+        print_stack_trace()
+    };
+
+    c();
 }
 
-fn print_sum(left: i32, right: i32) {
-    let sum = left + right;
-    println!("sum {:p}", &sum);
-    print(sum);
+#[no_mangle]
+fn c() {
+    unsafe {
+        println!("");
+        println!("c");
+        print_stack_trace()
+    };
+
+    d();
 }
 
-fn print(value: i32) {
-    println!("value {:p}", &value);
-    unsafe { print_stack_trace() };
+#[no_mangle]
+fn d() {
+    unsafe {
+        println!("");
+        println!("d");
+        print_stack_trace()
+    };
+
+    e();
 }
 
+#[no_mangle]
+fn e() {
+    unsafe {
+        println!("");
+        println!("e");
+        print_stack_trace()
+    };
+}
+
+#[inline(always)]
 unsafe fn print_stack_trace() {
     let mut fp: *const usize;
     unsafe { asm!("mv {}, fp", out(reg) fp) };


### PR DESCRIPTION
Previously, it's always printing
```
== Begin stack trace ==
ra = 0x0000000080400032, fp = 0x0000000080209000
ra = 0x0000000000000000, fp = 0x0000000000000000
== End stack trace ==
```
no matter how deep the call stack is.

After thinking and trial and error for some time, I realized the compiler must have done some optimization, and used the #[no_mangle] to prevent the optimization, it turned out to print
```
== Begin stack trace ==
ra = 0x8040085a, fp = 0x80208ac0
ra = 0x804006c0, fp = 0x80208c00
ra = 0x80400526, fp = 0x80208d40
ra = 0x8040038c, fp = 0x80208e80
ra = 0x804001f0, fp = 0x80208fc0
ra = 0x80400032, fp = 0x80209000
ra = 0x00000000, fp = 0x00000000
== End stack trace ==
```

as expected.